### PR TITLE
Sync Ruby version of Gemfile.lock with Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 2.2.3p173
+   ruby 2.2.5p319
 
 BUNDLED WITH
    1.12.5


### PR DESCRIPTION
Fixes #14.

The Ruby version specified in Gemfile.lock is not synced with the one specified in Gemfile. 
This PR updates the version in Gemfile.lock.

To test:
Go to branch [cyhsutw/sync-ruby-version](https://github.com/Moya/Aeryn/tree/cyhsutw/sync-ruby-version) and click the **Deploy to Heroku** button to deploy the app.