### PR TITLE
Updates rubocop to 0.51

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,8 +71,9 @@ GEM
       shellany (~> 0.0)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
-    parser (2.3.1.2)
-      ast (~> 2.2)
+    parallel (1.12.0)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -83,7 +84,9 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rainbow (2.1.0)
+    rainbow (2.2.2)
+      rake
+    rake (12.3.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -103,13 +106,14 @@ GEM
     rspec-sinatra (0.1.2)
       templater (>= 1.0.0)
     rspec-support (3.5.0)
-    rubocop (0.41.1)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.51.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.3.1)
     sawyer (0.7.0)
       addressable (>= 2.3.5, < 2.5)
@@ -127,7 +131,7 @@ GEM
     terminal-table (1.6.0)
     thor (0.19.1)
     tilt (2.0.5)
-    unicode-display_width (1.1.0)
+    unicode-display_width (1.3.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -153,4 +157,4 @@ RUBY VERSION
    ruby 2.2.5p319
 
 BUNDLED WITH
-   1.12.5
+   1.16.0


### PR DESCRIPTION
GitHub warned us about a known vulnerability in `rubocop <= 0.48.1`:

[CVE-2017-8418](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418):
>  RuboCop 0.48.1 and earlier does not use /tmp in safe way, allowing local users to exploit this to tamper with cache files belonging to other users.
