### PR TITLE
Fixes Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,16 +3,16 @@ has_test_changes = !git.modified_files.grep(/spec/).empty?
 
 # Sometimes it's a README fix, or something like that - which isn't relevant for
 # including in a project's CHANGELOG for example
-declared_trivial = pr_title.include? '#trivial'
+declared_trivial = github.pr_title.include? '#trivial'
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-warn('PR is classed as Work in Progress') if pr_title.include? '[WIP]'
+warn('PR is classed as Work in Progress') if github.pr_title.include? '[WIP]'
 
 # Warn when there is a big PR
-warn('Big PR') if lines_of_code > 500
+warn('Big PR') if git.lines_of_code > 500
 
 # Add a CHANGELOG entry for app changes
-if !modified_files.include?('CHANGELOG.md') && has_app_changes
+if !git.modified_files.include?('CHANGELOG.md') && has_app_changes
   fail('Please include a CHANGELOG entry.')
 end
 


### PR DESCRIPTION
From #31:

```
[!] Invalid Dangerfile file: undefined local variable or method pr_title for #<Danger::Dangerfile:0x00000002b03a40>. Updating the Danger gem might fix the issue. Your Danger version: 5.5.11, latest Danger version: 5.6.4

 #  from Dangerfile:6
 #  -------------------------------------------
 #  # including in a project's CHANGELOG for example
 >  declared_trivial = pr_title.include? '#trivial'
 #  
 #  -------------------------------------------
```