### PR TITLE
Locks minimum version for Sinatra as 2.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby '2.2.5'
 
-gem 'sinatra'
+gem 'sinatra', '~> 2.0.2'
 gem 'json'
 gem 'octokit'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     multipart-post (2.0.0)
-    mustermann (1.0.2)
+    mustermann (1.0.3)
     nap (1.1.0)
     nenv (0.3.0)
     no_proxy_fix (0.1.2)
@@ -94,7 +94,7 @@ GEM
       method_source (~> 0.9.0)
     public_suffix (3.0.2)
     rack (2.0.4)
-    rack-protection (2.0.1)
+    rack-protection (2.0.3)
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -130,10 +130,10 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     shellany (0.0.1)
-    sinatra (2.0.1)
+    sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.3)
       tilt (~> 2.0)
     templater (1.0.0)
       diff-lcs (>= 1.1.2)
@@ -163,7 +163,7 @@ DEPENDENCIES
   rspec-mocks
   rspec-sinatra
   rubocop
-  sinatra
+  sinatra (~> 2.0.2)
 
 RUBY VERSION
    ruby 2.2.5p319


### PR DESCRIPTION
A security vulnerability exists in version 2.0.1
Details: https://nvd.nist.gov/vuln/detail/CVE-2018-11627